### PR TITLE
カンムリ雪原巨人の寝床の固定シンボル28を追加

### DIFF
--- a/ShinySymbols.ino
+++ b/ShinySymbols.ino
@@ -6,6 +6,7 @@
 #include "k_mitsumata2.h"
 #include "k_nedoko26.h"
 #include "k_nedoko43.h"
+#include "k_nedoko28.h"
 
 int target;
 
@@ -65,6 +66,19 @@ void loop(){
         case NIDOQUEEN_NEDOKO43:
             {
                 KNedoko43 pokemon = KNedoko43(target);
+                pokemon.loop();
+            }
+            break;
+        case GALVANTULA:
+        case GLALIE:
+        case ALTARIA:
+        case BRONZONG:
+        case ABSOL:
+        case DUBWOOL:
+        case DURANT:
+        case CLEFABLE:
+            {
+                KNedoko28 pokemon = KNedoko28(target);
                 pokemon.loop();
             }
             break;

--- a/k_nedoko28.cpp
+++ b/k_nedoko28.cpp
@@ -1,0 +1,89 @@
+// カンムリ雪原 巨人の寝床 固定シンボル28
+// デンチュラ（雷雨）など
+// https://yakkun.com/swsh/map.htm?place=nedoko
+
+#include <auto_command_util.h>
+#include "modules.h"
+#include "k_nedoko28.h"
+
+KNedoko28::KNedoko28(int pokemon) {
+    this->symbol = pokemon;
+}
+
+void KNedoko28::moveToInitialPlayerPosition() {
+    openMap();
+
+    //カーソルを飛ぶ場所に合わせる
+    myPushHatButton(Hat::UP_RIGHT, 110, BUTTON_PUSHING_MSEC);
+    myPushHatButton(Hat::RIGHT, 80, BUTTON_PUSHING_MSEC);
+
+    myDelay(200);
+    
+    sky();
+}
+
+void KNedoko28::symbolEncount() {
+    // そらを飛ぶ地点から直接ポケモンに当たると
+    // 雪中渓谷の天気が反映されるためそれを避けるために
+    // いったん巣穴近くの木まで移動する
+    myTiltJoystick(-100, 0, 0, 0, 2500, 30);
+    myTiltJoystick(-9, -100, 0, 0, 1300, 30);
+    myTiltJoystick(10, -100, 0, 0, 2000, 30);
+    myTiltJoystick(10, 100, 0, 0, 300, 30);
+    myTiltJoystick(0, 100, 0, 0, 1000, 30);
+    myTiltJoystick(70, 100, 0, 0, 600, 30);
+    myTiltJoystick(100, 90, 0, 0, 1000, 30);
+    myTiltJoystick(100, 30, 0, 0, 600, 30);
+    myTiltJoystick(100, 85, 0, 0, 600, 30);
+    myTiltJoystick(0, 100, 0, 0, 950, 30);
+
+    myPush(Button::A, 200, 2);
+    myPush(Button::B, 200, 5);
+    myDelay(this->convertToMSecFromPokemon());
+    myPush(Button::B, 200, 5);
+
+    // 戦闘開始、色違い光モーションなければ十字上＞逃げる
+    // 色違いならば、1つめの上入力間に合わないため戦闘＞自爆技で自分側瀕死
+    // Aボタンを2回以上連続して押す場合は、次のポケモン選択画面で一番上以外のポケモンを繰り出さないようにする
+    myPushHatButton(Hat::UP, BUTTON_PUSHING_MSEC, 1000);
+    myPushButton(Button::A, BUTTON_PUSHING_MSEC, 800);
+    myPush(Button::B, 400, 2);
+    myPushHatButton(Hat::UP, 1500, BUTTON_PUSHING_MSEC);
+    myPush(Button::A, 800, 2);
+    myPush(Button::B, 100, 5);
+}
+
+int KNedoko28::convertToMSecFromPokemon() {
+    if (this->symbol == GALVANTULA) {
+        // 雨＋エレキフィールド＋かがくへんかガス
+        return 7500;
+    } else if (this->symbol == GLALIE) {
+        // 雪＋かがくへんかガス
+        return 6500;
+    } else if (this->symbol == ALTARIA) {
+        // かがくへんかガス
+        return 6000;
+    } else if (this->symbol == BRONZONG) {
+        // 雨＋かがくへんかガス
+        return 6500;
+    } else if (this->symbol == ABSOL) {
+        // 雪＋かがくへんかガス
+        return 6500;
+    } else if (this->symbol == DUBWOOL) {
+        // かがくへんかガス
+        return 6000;
+    } else if (this->symbol == DURANT) {
+        // 日照＋かがくへんかガス
+        return 6500;
+    } else if (this->symbol == CLEFABLE){
+        // 霧＋かがくへんかガス
+        return 6500;
+    }
+    return 5500;
+}
+
+void KNedoko28::loop() {
+    this->moveToInitialPlayerPosition();
+    this->symbolEncount();
+    execTimeLeap();
+}

--- a/k_nedoko28.h
+++ b/k_nedoko28.h
@@ -1,0 +1,16 @@
+#ifndef KNEDOKO28_H
+#define KNEDOKO28_H
+
+class KNedoko28 {
+public:
+    KNedoko28(int pokemon);
+    void loop();
+
+private:
+    void moveToInitialPlayerPosition();
+    void symbolEncount();
+    int convertToMSecFromPokemon();
+    int symbol;
+};
+
+#endif

--- a/modules.h
+++ b/modules.h
@@ -52,6 +52,14 @@ TIME_LEAP_MODE は時渡りバグを使うときの方法
 #define NIDOKING_NEDOKO43 21 // ニドキング（雨）
 #define GRIMMSNARL 22 // オーロンゲ
 #define NIDOQUEEN_NEDOKO43 23 // ニドクイン（日照）
+#define GALVANTULA 24 // デンチュラ（寝床28 雷雨）
+#define GLALIE 25 // オニゴーリ（寝床28 雪）
+#define ALTARIA 26 // チルタリス（寝床28 曇り）
+#define BRONZONG 27 // ドータクン（寝床28 雨）
+#define ABSOL 28 // アブソル（寝床28 吹雪）
+#define DUBWOOL 29 // バイウールー（寝床28 晴れ）
+#define DURANT 30 // アイアント（寝床28 日照）
+#define CLEFABLE 31 // ピクシー（寝床28 霧）
 
 const int TIME_LEAP_MODE = RANKBATTLE;
 

--- a/target.ino
+++ b/target.ino
@@ -8,5 +8,5 @@
 
 // return: int
 int setTarget(){
-    return STOUTLAND;
+    return CLEFABLE;
 }

--- a/target.ino
+++ b/target.ino
@@ -8,5 +8,5 @@
 
 // return: int
 int setTarget(){
-    return CLEFABLE;
+    return GLALIE;
 }


### PR DESCRIPTION
## 追加
```h
#define GALVANTULA 24 // デンチュラ（寝床28 雷雨）
#define GLALIE 25 // オニゴーリ（寝床28 雪）
#define ALTARIA 26 // チルタリス（寝床28 曇り）
#define BRONZONG 27 // ドータクン（寝床28 雨）
#define ABSOL 28 // アブソル（寝床28 吹雪）
#define DUBWOOL 29 // バイウールー（寝床28 晴れ）
#define DURANT 30 // アイアント（寝床28 日照）
#define CLEFABLE 31 // ピクシー（寝床28 霧）
```

## テスト
### テスト済み
- [ ] デンチュラ
- [ ] チルタリス
- [ ] ドータクン
- [ ] ピクシー